### PR TITLE
closed fds in popen calls to xclip

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -131,7 +131,7 @@ def _copyQt(text):
 
 
 def _copyXclip(text):
-    p = Popen(['xclip', '-selection', 'c'], stdin=PIPE)
+    p = Popen(['xclip', '-selection', 'c'], stdin=PIPE, close_fds=True)
     try:
         # works on Python 3 (bytes() requires an encoding)
         p.communicate(input=bytes(text, 'utf-8'))
@@ -141,7 +141,7 @@ def _copyXclip(text):
 
 
 def _pasteXclip():
-    p = Popen(['xclip', '-selection', 'c', '-o'], stdout=PIPE)
+    p = Popen(['xclip', '-selection', 'c', '-o'], stdout=PIPE, close_fds=True)
     stdout, stderr = p.communicate()
     return bytes.decode(stdout)
 


### PR DESCRIPTION
Hi, 
I was using pyperclip to add copy to clipboard feature to mitmproxy [https://github.com/mitmproxy/mitmproxy/pull/448] but @mhils realized that xclip retained ports open by mitmproxy.
using close_fds=True when calling popen fixes that. (xclip still remains for a while as a forked process but that's not longer an issue as it no longer has access to mitmproxy's ports).
I don't know if xsel or pb(copy|paste) suffer from the same issue.
Regards.
Marcelo