### PR TITLE
xsel: copy to clipboard, don't inherit fds

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -94,7 +94,7 @@ def _copyCygwin(text):
 
 def _copyOSX(text):
     text = str(text)
-    p = Popen(['pbcopy', 'w'], stdin=PIPE)
+    p = Popen(['pbcopy', 'w'], stdin=PIPE, close_fds=True)
     try:
         # works on Python 3 (bytes() requires an encoding)
         p.communicate(input=bytes(text, 'utf-8'))
@@ -104,7 +104,7 @@ def _copyOSX(text):
 
 
 def _pasteOSX():
-    p = Popen(['pbpaste', 'r'], stdout=PIPE)
+    p = Popen(['pbpaste', 'r'], stdout=PIPE, close_fds=True)
     stdout, stderr = p.communicate()
     return bytes.decode(stdout)
 
@@ -147,7 +147,7 @@ def _pasteXclip():
 
 
 def _copyXsel(text):
-    p = Popen(['xsel', '-i'], stdin=PIPE)
+    p = Popen(['xsel', '-b', '-i'], stdin=PIPE, close_fds=True)
     try:
         # works on Python 3 (bytes() requires an encoding)
         p.communicate(input=bytes(text, 'utf-8'))
@@ -157,7 +157,7 @@ def _copyXsel(text):
 
 
 def _pasteXsel():
-    p = Popen(['xsel', '-o'], stdout=PIPE)
+    p = Popen(['xsel', '-b', '-o'], stdout=PIPE, close_fds=True)
     stdout, stderr = p.communicate()
     return bytes.decode(stdout)
 


### PR DESCRIPTION
Hi @asweigart,

thanks for your pyperclip library! As indicated by @gato, we're in the process of integrating that into mitmproxy. While testing, we stumbled upon two additional issues:

1. the subprocesses should never inherit the file handles - as I see it, there's no reason for that (and it keeps our proxy port open after closing the application).
2. xsel should probably copy to clipboard rather than to PRIMARY, as xclip does. This might be the root cause of the "xsel doesn't seem to work on Raspberry Pi" comment in the source as well. I can't confirm that, so I left it in.

On another note, we'd love to see a quick pyperclip release with these fixes. I'm a bit reluctant to merge the mitmproxy additions as long as they may introduce undesired side effects.

Thanks for responding to the previous PR so quickly!

Cheers,
Max