### PR TITLE
fix returned values, when sys.getdefaultencoding() is ascii

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -91,7 +91,7 @@ def _copyOSX(text):
 def _pasteOSX():
     p = Popen(['pbpaste', 'r'], stdout=PIPE, close_fds=True)
     stdout, stderr = p.communicate()
-    return bytes.decode(stdout)
+    return stdout.decode('utf-8')
 
 
 def _pasteGtk():
@@ -123,7 +123,7 @@ def _copyXclip(text):
 def _pasteXclip():
     p = Popen(['xclip', '-selection', 'c', '-o'], stdout=PIPE, close_fds=True)
     stdout, stderr = p.communicate()
-    return bytes.decode(stdout)
+    return stdout.decode('utf-8')
 
 
 def _copyXsel(text):
@@ -134,7 +134,7 @@ def _copyXsel(text):
 def _pasteXsel():
     p = Popen(['xsel', '-b', '-o'], stdout=PIPE, close_fds=True)
     stdout, stderr = p.communicate()
-    return bytes.decode(stdout)
+    return stdout.decode('utf-8')
 
 
 


### PR DESCRIPTION
Hi there!

I've found a problem, when I tried to run pyperclip on Ubuntu Linux.

Steps to reproduce the problem:
1. Create virtualenv environment.
2. Install pyperclip package via pip inside this environment.
3. pyperclip.paste() give an error like:

```
/local/lib/python2.7/site-packages/pyperclip/__init__.py", line 126, in _pasteXclip
    return bytes.decode(stdout)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 8: ordinal not in range(128)
```

The reason is that **gtk** module is not imported inside env. gtk module changed default encoding to utf-8, therefore pyperclip is working when installed in the system directory:
```
sudo pip install pyperclip 
```