### PR TITLE
remove str() from _copy functions. Fix for ascii default encoding

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -83,7 +83,6 @@ def _copyCygwin(text):
 
 
 def _copyOSX(text):
-    text = str(text)
     p = Popen(['pbcopy', 'w'], stdin=PIPE, close_fds=True)
     p.communicate(input=text.encode('utf-8'))
 
@@ -100,7 +99,6 @@ def _pasteGtk():
 
 def _copyGtk(text):
     global cb
-    text = str(text)
     cb = gtk.Clipboard()
     cb.set_text(text)
     cb.store()
@@ -111,7 +109,6 @@ def _pasteQt():
 
 
 def _copyQt(text):
-    text = str(text)
     cb.setText(text)
 
 


### PR DESCRIPTION
Hello!

I have made some tests on OS X and found another problem. When you try to copy Unicode string an error appears:
```
    pyperclip.copy(msg)
  File "/Users/admin/code/.virtualenvs/test/lib/python2.7/site-packages/pyperclip/__init__.py", line 86, in _copyOSX
    text = str(text)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 10: ordinal not in range(128)
```
I think, it's better to remove str() and use Unicode string for all _copy functions.