### PR TITLE
Fix test_copyUnicode under PyPy

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -141,6 +141,8 @@ def _copyQt(text):
 
 
 def _copyXclip(text):
+    if not isinstance(text, STRING_FUNCTION):
+        text = text.decode('utf-8')
     p = Popen(['xclip', '-selection', 'c'], stdin=PIPE, close_fds=True)
     p.communicate(input=text.encode('utf-8'))
 
@@ -152,6 +154,8 @@ def _pasteXclip():
 
 
 def _copyXsel(text):
+    if not isinstance(text, STRING_FUNCTION):
+        text = text.decode('utf-8')
     p = Popen(['xsel', '-b', '-i'], stdin=PIPE, close_fds=True)
     p.communicate(input=text.encode('utf-8'))
 
@@ -163,6 +167,8 @@ def _pasteXsel():
 
 
 def _copyKlipper(text):
+    if not isinstance(text, STRING_FUNCTION):
+        text = text.decode('utf-8')
     p = Popen(['qdbus', 'org.kde.klipper', '/klipper',
             'setClipboardContents', text.encode('utf-8')],
              stdin=PIPE, close_fds=True)


### PR DESCRIPTION
`test_copyUnicode` failed with a `UnicodeDecodeError` when calling `text.encode('utf-8')` here under PyPy 2.6.1. This PR copies the approach for Windows to all the 3 linux methods that make use of `text.encode('utf-8')` and passed all tests here.

```
Testing on: Python 2.7.10 - xclip command
.E..
======================================================================
ERROR: test_copyUnicode (__main__.TestCopyPaste)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/basicTests.py", line 32, in test_copyUnicode
    pyperclip.copy('ಠ_ಠ')
  File "tests/../pyperclip/__init__.py", line 117, in _copyXclip
    p.communicate(input=text.encode('utf-8'))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe0 in position 0: ordinal not in range(128)
```