### PR TITLE
_pasteKlipper: remove last newline if exists

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -181,10 +181,8 @@ def _pasteKlipper():
     # https://bugs.kde.org/show_bug.cgi?id=342874
 
     clipboardContents = stdout.decode('utf-8')
-    assert len(clipboardContents) > 0 # even if blank, Klipper will append a newline at the end
-    assert clipboardContents[-1] == '\n' # make sure that newline is there
-    if len(clipboardContents) and clipboardContents[-1] == '\n':
-        clipboardContents = clipboardContents[:-1]
+    if clipboardContents.endswith('\n'):
+      clipboardContents = clipboardContents[:-1]
     return clipboardContents
 
 def setFunctions(functionSet):


### PR DESCRIPTION
Hello!

Sorry for the previous pull request. It was heedless.

I think that length of clipboardContents is unnecessary and endswith('\n') is more readable for comparison.