### PR TITLE
Fix Windows Method

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -25,8 +25,9 @@ __version__ = '1.5.20'
 import platform
 import os
 import subprocess
-from .clipboards import (init_windows_clipboard, init_gtk_clipboard, init_klipper_clipboard, init_osx_clipboard,
+from .clipboards import (init_gtk_clipboard, init_klipper_clipboard, init_osx_clipboard,
                          init_qt_clipboard, init_xclip_clipboard, init_xsel_clipboard, init_no_clipboard)
+from .windows import init_windows_clipboard
 
 PY2 = '2' == platform.python_version_tuple()[0]
 STRING_FUNCTION = unicode if PY2 else str

--- a/pyperclip/clipboards.py
+++ b/pyperclip/clipboards.py
@@ -1,44 +1,8 @@
-import sys, subprocess, ctypes
+import sys
+import subprocess
+from .exceptions import PyperclipException
 
 PY2 = sys.version_info[0] == 2
-text_type = unicode if PY2 else str
-
-
-def init_windows_clipboard(cygwin=False):
-    if cygwin:
-        d = ctypes.cdll
-    else:
-        d = ctypes.windll
-
-    CF_UNICODETEXT = 13
-    GMEM_DDESHARE = 0x2000
-
-    def copy_windows(text):
-        if not isinstance(text, text_type):
-            text = text.decode('mbcs')
-
-        d.user32.OpenClipboard(0)
-        d.user32.EmptyClipboard()
-        hCd = d.kernel32.GlobalAlloc(GMEM_DDESHARE, len(text.encode('utf-16-le')) + 2)
-        pchData = d.kernel32.GlobalLock(hCd)
-
-        # Detects this error: "OSError: exception: access violation writing 0x0000000000000000"
-        # if pchData == 0:
-        #    assert False, 'GlobalLock() returned NULL. GetLastError() returned' + str(ctypes.GetLastError())
-
-        ctypes.cdll.msvcrt.wcscpy(ctypes.c_wchar_p(pchData), text)
-        d.kernel32.GlobalUnlock(hCd)
-        d.user32.SetClipboardData(CF_UNICODETEXT, hCd)
-        d.user32.CloseClipboard()
-
-    def paste_windows():
-        d.user32.OpenClipboard(0)
-        handle = d.user32.GetClipboardData(CF_UNICODETEXT)
-        data = ctypes.c_wchar_p(handle).value
-        d.user32.CloseClipboard()
-        return data
-
-    return copy_windows, paste_windows
 
 
 def init_osx_clipboard():
@@ -153,7 +117,7 @@ def init_klipper_clipboard():
 def init_no_clipboard():
     class ClipboardUnavailable(object):
         def __call__(self, *args, **kwargs):
-            raise RuntimeError(
+            raise PyperclipException(
                 'Pyperclip could not find a copy/paste mechanism for your system. '
                 'Please see https://pyperclip.readthedocs.org for how to fix this.'
             )

--- a/pyperclip/exceptions.py
+++ b/pyperclip/exceptions.py
@@ -1,0 +1,11 @@
+import ctypes
+
+
+class PyperclipException(RuntimeError):
+    pass
+
+
+class PyperclipWindowsException(PyperclipException):
+    def __init__(self, message):
+        message += " (%s)" % ctypes.WinError()
+        super(PyperclipWindowsException, self).__init__(message)

--- a/pyperclip/windows.py
+++ b/pyperclip/windows.py
@@ -1,0 +1,147 @@
+"""
+This module implements clipboard handling on Windows using ctypes.
+"""
+import time
+import contextlib
+import ctypes
+from ctypes import c_size_t, sizeof, c_wchar_p, get_errno, c_wchar
+from ctypes.wintypes import HGLOBAL, LPVOID, DWORD, LPCSTR, INT, HWND, HINSTANCE, HMENU, BOOL, UINT, HANDLE
+from .exceptions import PyperclipWindowsException
+
+
+class CheckedCall(object):
+    def __init__(self, f):
+        super(CheckedCall, self).__setattr__("f", f)
+
+    def __call__(self, *args):
+        ret = self.f(*args)
+        if not ret and get_errno():
+            raise PyperclipWindowsException("Error calling " + self.f.__name__)
+        return ret
+
+    def __setattr__(self, key, value):
+        setattr(self.f, key, value)
+
+
+def init_windows_clipboard(cygwin=False):
+    if cygwin:
+        windll = ctypes.cdll  # TODO: This is untested
+    else:
+        windll = ctypes.windll
+
+    safeCreateWindowExA = CheckedCall(windll.user32.CreateWindowExA)
+    safeCreateWindowExA.argtypes = [DWORD, LPCSTR, LPCSTR, DWORD, INT, INT, INT, INT, HWND, HMENU, HINSTANCE, LPVOID]
+    safeCreateWindowExA.restype = HWND
+
+    safeDestroyWindow = CheckedCall(windll.user32.DestroyWindow)
+    safeDestroyWindow.argtypes = [HWND]
+    safeDestroyWindow.restype = BOOL
+
+    OpenClipboard = windll.user32.OpenClipboard
+    OpenClipboard.argtypes = [HWND]
+    OpenClipboard.restype = BOOL
+
+    safeCloseClipboard = CheckedCall(windll.user32.CloseClipboard)
+    safeCloseClipboard.argtypes = []
+    safeCloseClipboard.restype = BOOL
+
+    safeEmptyClipboard = CheckedCall(windll.user32.EmptyClipboard)
+    safeEmptyClipboard.argtypes = []
+    safeEmptyClipboard.restype = BOOL
+
+    safeGetClipboardData = CheckedCall(windll.user32.GetClipboardData)
+    safeGetClipboardData.argtypes = [UINT]
+    safeGetClipboardData.restype = HANDLE
+
+    safeSetClipboardData = CheckedCall(windll.user32.SetClipboardData)
+    safeSetClipboardData.argtypes = [UINT, HANDLE]
+    safeSetClipboardData.restype = HANDLE
+
+    safeGlobalAlloc = CheckedCall(windll.kernel32.GlobalAlloc)
+    safeGlobalAlloc.argtypes = [UINT, c_size_t]
+    safeGlobalAlloc.restype = HGLOBAL
+
+    safeGlobalLock = CheckedCall(windll.kernel32.GlobalLock)
+    safeGlobalLock.argtypes = [HGLOBAL]
+    safeGlobalLock.restype = LPVOID
+
+    safeGlobalUnlock = CheckedCall(windll.kernel32.GlobalUnlock)
+    safeGlobalUnlock.argtypes = [HGLOBAL]
+    safeGlobalUnlock.restype = BOOL
+
+    wcscpy_s = ctypes.cdll.msvcrt.wcscpy_s
+    wcscpy_s.argtypes = [c_wchar_p, c_size_t, c_wchar_p]
+    wcscpy_s.restype = c_wchar_p
+
+    GMEM_MOVEABLE = 0x0002
+    CF_UNICODETEXT = 13
+
+    @contextlib.contextmanager
+    def window():
+        """
+        Context that provides a valid Windows hwnd.
+        """
+        # we really just need the hwnd, so setting "STATIC" as predefined lpClass is just fine.
+        hwnd = safeCreateWindowExA(0, b"STATIC", None, 0, 0, 0, 0, 0, None, None, None, None)
+        try:
+            yield hwnd
+        finally:
+            safeDestroyWindow(hwnd)
+
+    @contextlib.contextmanager
+    def clipboard(hwnd):
+        """
+        Context manager that opens the clipboard and prevents other applications from modifying the clipboard content.
+        """
+        # We may not get the clipboard handle immediately because some other application is accessing it (?)
+        # We try for at least 500ms to get the clipboard.
+        t = time.time() + 0.5
+        success = False
+        while time.time() < t:
+            success = OpenClipboard(hwnd)
+            if success:
+                break
+            time.sleep(0.01)
+        if not success:
+            raise PyperclipWindowsException("Error calling OpenClipboard")
+
+        try:
+            yield
+        finally:
+            safeCloseClipboard()
+
+    def copy_windows(text):
+        # This function is heavily based on
+        # https://msdn.microsoft.com/de-de/library/windows/desktop/ms649016(v=vs.85).aspx#_win32_Copying_Information_to_the_Clipboard
+
+        with window() as hwnd:
+            # https://msdn.microsoft.com/de-de/library/windows/desktop/ms649048(v=vs.85).aspx
+            # > If an application calls OpenClipboard with hwnd set to NULL, EmptyClipboard sets the clipboard owner to
+            # > NULL; this causes SetClipboardData to fail.
+            # => We need a valid hwnd to copy something.
+            with clipboard(hwnd):
+                safeEmptyClipboard()
+
+                if text:
+                    # https://msdn.microsoft.com/de-de/library/windows/desktop/ms649051(v=vs.85).aspx
+                    # > If the hMem parameter identifies a memory object, the object must have been allocated using the
+                    # > function with the GMEM_MOVEABLE flag.
+                    handle = safeGlobalAlloc(GMEM_MOVEABLE, (len(text) + 1) * sizeof(c_wchar))
+                    locked_handle = safeGlobalLock(handle)
+
+                    if wcscpy_s(c_wchar_p(locked_handle), len(text) + 1, c_wchar_p(text)):
+                        raise PyperclipWindowsException("Error calling wcscpy_s")
+
+                    safeGlobalUnlock(handle)
+                    safeSetClipboardData(CF_UNICODETEXT, handle)
+
+    def paste_windows():
+        with clipboard(None):
+            handle = safeGetClipboardData(CF_UNICODETEXT)
+            if not handle:
+                # GetClipboardData may return NULL with errno == NO_ERROR if the clipboard is empty.
+                # (Also, it may return a handle to an empty buffer, but technically that's not empty)
+                return ""
+            return c_wchar_p(handle).value
+
+    return copy_windows, paste_windows

--- a/tests/test_copy_paste.py
+++ b/tests/test_copy_paste.py
@@ -6,7 +6,8 @@ import os
 import platform
 from pyperclip import _executable_exists
 from pyperclip.clipboards import (init_gtk_clipboard, init_xsel_clipboard, init_xclip_clipboard, init_klipper_clipboard,
-                                  init_qt_clipboard, init_osx_clipboard, init_no_clipboard, init_windows_clipboard)
+                                  init_qt_clipboard, init_osx_clipboard, init_no_clipboard)
+from pyperclip.windows import init_windows_clipboard
 
 
 class _TestClipboard(unittest.TestCase):


### PR DESCRIPTION
The Windows method was a bit unstable on my system, so I decided to rewrite it in the most cautious way possible based on the MSDN docs

- `GlobalAlloc` is called with `GMEM_MOVEABLE` as required by `SetClipboardData`
- We do the full dance and pass a valid hwnd to `OpenClipboard`, as required by the [SetClipboardData docs](https://msdn.microsoft.com/de-de/library/windows/desktop/ms649051(v=vs.85).aspx)
- If `OpenClipboard` fails the first time, we repeatedly try to get the clipboard lock for up to 500ms.
- Fixed support for Python 3.5 x64 (`HANDLE` apparently as different sizes on x32 and x64, thus we must specify argtypes and restype for each API call)
- Every Windows API call gets now checked for potential errors
- Removed `.decode('mbcs')` call. On Python 2.7, c_wchar_p apparently auto-converts bytes to unicode. On Python 3.5, calling the method with bytes returns a fairly descriptive `TypeError: unicode string or integer address expected instead of bytes instance`error. If there are issues with that, there should be tests to cover this.
- Given the verbosity, I moved the Windows-specific code in its own file.

This should fix #5, fix #7, fix #10, fix #16, fix #21, fix #25.
It should also fix #27 and #35 by making them obsolete.