### PR TITLE
Use local pyperclip in tests

### DIFF
--- a/tests/test_copy_paste.py
+++ b/tests/test_copy_paste.py
@@ -1,9 +1,13 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 import string
 import unittest
 import random
 import os
 import platform
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
 from pyperclip import _executable_exists, HAS_DISPLAY
 from pyperclip.clipboards import (init_gtk_clipboard, init_xsel_clipboard, init_xclip_clipboard, init_klipper_clipboard,
                                   init_qt_clipboard, init_osx_clipboard, init_no_clipboard)


### PR DESCRIPTION
Now tests are using not local pyperclip module. This PR change path to use local pyperclip for testing.