### PR TITLE
Disable broken cygwin implementation

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -50,8 +50,10 @@ def determine_clipboard():
     # Determine the OS/platform and set
     # the copy() and paste() functions accordingly.
     if 'cygwin' in platform.system().lower():
-        return init_windows_clipboard(cygwin=True)
-    if os.name == 'nt' or platform.system() == 'Windows':
+        # FIXME: pyperclip currently does not support Cygwin,
+        # see https://github.com/asweigart/pyperclip/issues/55
+        pass
+    elif os.name == 'nt' or platform.system() == 'Windows':
         return init_windows_clipboard()
     if os.name == 'mac' or platform.system() == 'Darwin':
         return init_osx_clipboard()

--- a/pyperclip/windows.py
+++ b/pyperclip/windows.py
@@ -22,14 +22,11 @@ class CheckedCall(object):
         setattr(self.f, key, value)
 
 
-def init_windows_clipboard(cygwin=False):
+def init_windows_clipboard():
     from ctypes.wintypes import (HGLOBAL, LPVOID, DWORD, LPCSTR, INT, HWND,
                                  HINSTANCE, HMENU, BOOL, UINT, HANDLE)
 
-    if cygwin:
-        windll = ctypes.cdll  # TODO: This is untested
-    else:
-        windll = ctypes.windll
+    windll = ctypes.windll
 
     safeCreateWindowExA = CheckedCall(windll.user32.CreateWindowExA)
     safeCreateWindowExA.argtypes = [DWORD, LPCSTR, LPCSTR, DWORD, INT, INT,


### PR DESCRIPTION
This PR disables the broken Cygwin implementation so that we don't get an exception when installing pyperclip at the very least. 
As discussed in https://github.com/asweigart/pyperclip/issues/55, the proper way would be to implement support for Cygwin's  `/dev/clipboard`.