### PR TITLE
Initial commit of lazy initialization functionality

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -10,7 +10,7 @@ Usage:
   pyperclip.copy('The text to be copied to the clipboard.')
   spam = pyperclip.paste()
 
-  if not pyperclip.copy:
+  if not pyperclip.is_available():
     print("Copy functionality unavailable!")
 
 On Windows, no additional modules are needed.
@@ -28,6 +28,7 @@ __version__ = '1.5.27'
 import platform
 import os
 import subprocess
+import warnings
 from .clipboards import (init_osx_clipboard,
                          init_gtk_clipboard, init_qt_clipboard,
                          init_xclip_clipboard, init_xsel_clipboard,
@@ -46,58 +47,151 @@ def _executable_exists(name):
                            stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
 
 
+class _PyperclipBackend(object):
+    """
+    A singleton class to manage the clipboard backend.
+
+    This class lazilly initializes the clipboard manager which allows the user
+    to attempt to set the clipboard without automatically importing modules
+    like PyQt4 or gtk.
+    """
+    def __init__(self):
+        self.clipboard = None
+        self.copy = self._first_copy
+        self.paste = self._first_paste
+
+    def _lazy_init(self):
+        if self.clipboard is None:
+            self._determine_clipboard()
+
+    def _determine_clipboard(self):
+        clipboard = self._find_valid_backend()
+        self._set_clipboard(clipboard)
+
+    def _find_valid_backend(self):
+        # Determine the OS/platform and set
+        # the copy() and paste() functions accordingly.
+        if 'cygwin' in platform.system().lower():
+            # FIXME: pyperclip currently does not support Cygwin,
+            warnings.warn('pyperclip currently does not support Cygwin,'
+                          'see https://github.com/asweigart/pyperclip/issues/55')
+        elif os.name == 'nt' or platform.system() == 'Windows':
+            return 'windows'
+        if os.name == 'mac' or platform.system() == 'Darwin':
+            return 'osx'
+        if HAS_DISPLAY:
+            # Determine which command/module is installed, if any.
+            try:
+                import gtk  # check if gtk is installed
+            except ImportError:
+                pass
+            else:
+                return 'gtk'
+
+            try:
+                import PyQt4  # check if PyQt4 is installed
+            except ImportError:
+                pass
+            else:
+                return 'qt'
+
+            if _executable_exists("xclip"):
+                return 'xclip'
+            if _executable_exists("xsel"):
+                return 'xsel'
+            if _executable_exists("klipper") and _executable_exists("qdbus"):
+                return 'klipper'
+
+        return 'no'
+
+    def _first_copy(self, text):
+        # If the backend hasn't been initialized determine a valid clipboard
+        self._lazy_init()
+        self.copy(text)
+
+    def _first_paste(self):
+        # If the backend hasn't been initialized determine a valid clipboard
+        self._lazy_init()
+        return self.paste()
+
+    def _set_clipboard(self, clipboard):
+        self.clipboard = clipboard
+        clipboard_types = {'osx': init_osx_clipboard,
+                           'gtk': init_gtk_clipboard,
+                           'qt': init_qt_clipboard,
+                           'xclip': init_xclip_clipboard,
+                           'xsel': init_xsel_clipboard,
+                           'klipper': init_klipper_clipboard,
+                           'windows': init_windows_clipboard,
+                           'no': init_no_clipboard}
+        self.copy, self.paste = clipboard_types[clipboard]()
+
+
+# Create a global singleton backend instance
+_backend = _PyperclipBackend()
+
+
+def is_available():
+    """
+    Checks if clipboard functionality is available
+
+    Returns:
+        bool: True if a valid backend exists
+    """
+    _backend._lazy_init()
+    return bool(_backend.copy)
+
+
 def determine_clipboard():
-    # Determine the OS/platform and set
-    # the copy() and paste() functions accordingly.
-    if 'cygwin' in platform.system().lower():
-        # FIXME: pyperclip currently does not support Cygwin,
-        # see https://github.com/asweigart/pyperclip/issues/55
-        pass
-    elif os.name == 'nt' or platform.system() == 'Windows':
-        return init_windows_clipboard()
-    if os.name == 'mac' or platform.system() == 'Darwin':
-        return init_osx_clipboard()
-    if HAS_DISPLAY:
-        # Determine which command/module is installed, if any.
-        try:
-            import gtk  # check if gtk is installed
-        except ImportError:
-            pass
-        else:
-            return init_gtk_clipboard()
+    """
+    Initializes the clipboard backend
 
-        try:
-            import PyQt4  # check if PyQt4 is installed
-        except ImportError:
-            pass
-        else:
-            return init_qt_clipboard()
-
-        if _executable_exists("xclip"):
-            return init_xclip_clipboard()
-        if _executable_exists("xsel"):
-            return init_xsel_clipboard()
-        if _executable_exists("klipper") and _executable_exists("qdbus"):
-            return init_klipper_clipboard()
-
-    return init_no_clipboard()
+    Returns:
+        tuple: the copy and paste function
+    """
+    _backend._lazy_init()
+    return _backend.copy, _backend.paste
 
 
 def set_clipboard(clipboard):
-    global copy, paste
+    """
+    Sets the current clipboard backend
 
-    clipboard_types = {'osx': init_osx_clipboard,
-                       'gtk': init_gtk_clipboard,
-                       'qt': init_qt_clipboard,
-                       'xclip': init_xclip_clipboard,
-                       'xsel': init_xsel_clipboard,
-                       'klipper': init_klipper_clipboard,
-                       'windows': init_windows_clipboard,
-                       'no': init_no_clipboard}
-
-    copy, paste = clipboard_types[clipboard]()
+    Args:
+        clipboard (str): one of the following values
+            'osx', 'gtk', 'qt', 'xclip', 'xsel', 'klipper', 'windows', or 'no'
+    """
+    _backend._set_clipboard(clipboard)
 
 
-copy, paste = determine_clipboard()
+def get_clipboard():
+    """
+    Returns the current clipboard backend
+
+    Returns:
+        str: the clipboard backend
+    """
+    return _backend.clipboard
+
+
+def copy(text):
+    """
+    Populates the clipboard
+
+    Args:
+        text (str): string to copy into the clipboard
+    """
+    _backend.copy(text)
+
+
+def paste():
+    """
+    Get the current text in the clipboard
+
+    Returns:
+        str: the current content of the clipboard
+    """
+    return _backend.paste()
+
 
 __all__ = ["copy", "paste"]

--- a/pyperclip/clipboards.py
+++ b/pyperclip/clipboards.py
@@ -1,5 +1,7 @@
 import sys
 import subprocess
+import os
+import platform
 from .exceptions import PyperclipException
 
 EXCEPT_MSG = """
@@ -10,6 +12,8 @@ text_type = unicode if PY2 else str
 
 
 def init_osx_clipboard():
+    assert os.name == 'mac' or platform.system() == 'Darwin', (
+        'Tried to initialize osx clipboard on a non-osx system')
     def copy_osx(text):
         p = subprocess.Popen(['pbcopy', 'w'],
                              stdin=subprocess.PIPE, close_fds=True)

--- a/pyperclip/windows.py
+++ b/pyperclip/windows.py
@@ -3,6 +3,8 @@ This module implements clipboard handling on Windows using ctypes.
 """
 import time
 import contextlib
+import os
+import platform
 import ctypes
 from ctypes import c_size_t, sizeof, c_wchar_p, get_errno, c_wchar
 from .exceptions import PyperclipWindowsException
@@ -23,6 +25,8 @@ class CheckedCall(object):
 
 
 def init_windows_clipboard():
+    assert os.name == 'nt' or platform.system() == 'Windows', (
+        'Tried to initialize windows clipboard on a non-win32 system')
     from ctypes.wintypes import (HGLOBAL, LPVOID, DWORD, LPCSTR, INT, HWND,
                                  HINSTANCE, HMENU, BOOL, UINT, HANDLE)
 


### PR DESCRIPTION
This patch addresses issue #67 where PyQt4 is automatically as the clipboard and there is nothing the user can do to prevent PyQt from being imported. 

The major problem is that the default backend is determined on import. This means that a linux developer cannot choose what the backend will be ahead of time and can lead to problems if the import of PyQt4 of gtk breaks. I've attempted to resolve this issue by changing the behavior of the module to delay choosing the backend until a copy or paste function is called. 

In this PR I wanted to be very conscious not to break any currently existing functionality. Unfortunately, the only behavior I was unable to preserve was: `bool(pyperclip.copy)` resulting in a truth value indicating if copy functionality is available. This is ameliorated by the addition of an is_available function that serves the same purpose. 

The approach I took to fixing the issue is to create a singleton PyperclipBackend object that manages the backends. A single instance is constructed at import time. Its attributes copy and paste are initially set to a _first_copy and _first_paste object which will do the initialization if called. The initialization will overwrite the backend's copy and paste function with the appropriate ones, so the initialization check is only run a single time. 

The backend object is completely hidden from the user. I define closure functions which wrap the copy and paste functionality. (Note; these closures are the reason why `bool(pyperclip.copy)`  will no longer work). 

I added documentation strings for all new functions. 

To show how the new code works consider this example: 

``` python
import pyperclip
# Lazy initialization has not been done, the returned clipboard is None
print('clipboard = %r' % (pyperclip.get_clipboard(),))
# The user specifies that xclip will be the default clipboard. The program never attempts to import PyQT4 or gtk. 
pyperclip.set_clipboard('xclip')
# Copy functionality can now be used
pyperclip.copy('The text to be copied to the clipboard.')
print('clipboard = %r' % (pyperclip.get_clipboard(),))
```

The old way of interacting with the module still exists. Consider this example: 

``` python
import pyperclip
# Lazy initialization has not been done, the returned clipboard is None
print('clipboard = %r' % (pyperclip.get_clipboard(),))
# The user tries to copy before setting the clipboard. Lazy initialization 
# performs the same step that used to be done on import. 
pyperclip.copy('The text to be copied to the clipboard.')
# A second call to either copy or paste will not re-run initialization 
# or even any checks! It just directly calls the backend copy/paste functions
# set in the initialization step
pyperclip.copy('The new text to be copied to the clipboard.')
print('clipboard = %r' % (pyperclip.get_clipboard(),))
```

---

In addition to this functionality I also added imports asserting you are on the correct systems if you try to erroneously set the backend to osx/windows and you are not on that platform. Also a warning is explicitly raised if you try to user pyperclip on cygwin. 

---

Hopefully this pull is in line with the author's standards. Please let me know if anything should be changed / re-worked / further explained. 
