### PR TITLE
Mac OS name is 'posix'

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -55,7 +55,7 @@ def determine_clipboard():
         pass
     elif os.name == 'nt' or platform.system() == 'Windows':
         return init_windows_clipboard()
-    if os.name == 'mac' or platform.system() == 'Darwin':
+    if os.name == 'posix' or platform.system() == 'Darwin':
         return init_osx_clipboard()
     if HAS_DISPLAY:
         # Determine which command/module is installed, if any.

--- a/tests/test_copy_paste.py
+++ b/tests/test_copy_paste.py
@@ -74,7 +74,7 @@ class TestWindows(_TestClipboard):
 
 
 class TestOSX(_TestClipboard):
-    if os.name == 'mac' or platform.system() == 'Darwin':
+    if os.name == 'posix' or platform.system() == 'Darwin':
         clipboard = init_osx_clipboard()
 
 


### PR DESCRIPTION
Closes #76.

```
Python 2.7.12 (default, Sep 28 2016, 18:41:32) 
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
.>>> import os
>>> os.name
'posix'
>>> import platform
>>> platform.system()
'Darwin'
>>> 
```