### PR TITLE
add `pyperclip` executable

### DIFF
--- a/bin/pyperclip
+++ b/bin/pyperclip
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+from pyperclip import cli
+cli.main()

--- a/pyperclip/cli.py
+++ b/pyperclip/cli.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+from optparse import OptionParser
+import re
+import sys
+import pyperclip
+
+def copy():
+    contents = sys.stdin.read().decode('utf-8')
+    contents = re.sub('\r?\n?$', '', contents) # trim trailing NL
+    pyperclip.copy(contents)
+    return
+
+def paste():
+    contents = pyperclip.paste()
+    print(contents.encode('utf-8'))
+
+def main():
+    p = OptionParser()
+    p.add_option('-i','--copy', action='store_const', const=copy, dest='action', default=copy)
+    p.add_option('-o','--paste', action='store_const', const=paste, dest='action')
+    opts, args = p.parse_args()
+    assert len(args) == 0
+    opts.action()

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     author='Al Sweigart',
     author_email='al@inventwithpython.com',
     description=('A cross-platform clipboard module for Python. (only handles plain text for now)'),
+    scripts=['bin/pyperclip'],
     license='BSD',
     packages=['pyperclip'],
     test_suite='tests',

--- a/tests/test_copy_paste.py
+++ b/tests/test_copy_paste.py
@@ -4,10 +4,14 @@ import unittest
 import random
 import os
 import platform
+import subprocess
 
 import sys
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.join(os.path.dirname(__file__), '..')
+sys.path.insert(0, project_root)
+os.environ['PATH'] = os.path.join(project_root, 'bin') + os.pathsep + os.environ['PATH']
 
+import pyperclip
 from pyperclip import _executable_exists, HAS_DISPLAY
 from pyperclip.clipboards import (init_osx_clipboard,
                                   init_gtk_clipboard, init_qt_clipboard,
@@ -124,6 +128,33 @@ class TestNoClipboard(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.paste()
 
+class TestCLI(unittest.TestCase):
+    def setUp(self):
+        super(TestCLI, self).setUp()
+        self.unicode = u"ಠ_ಠ %d\n" % (random.randint(0, 999))
+
+    def _run(this, *args):
+        return subprocess.Popen(['pyperclip'] + list(args),
+            stdin = subprocess.PIPE,
+            stdout = subprocess.PIPE,
+            stderr = subprocess.STDOUT
+        )
+
+    def test_copy(self):
+        proc = self._run('--copy')
+        output, _ = proc.communicate((self.unicode).encode('utf-8'))
+
+        self.assertEqual(output, '')
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(pyperclip.paste(), self.unicode.strip())
+
+    def test_paste(self):
+        pyperclip.copy(self.unicode.strip())
+        proc = self._run('--paste')
+        output, _ = proc.communicate()
+
+        self.assertEqual(output.decode('utf-8'), self.unicode)
+        self.assertEqual(proc.poll(), 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
👋 Hi there, thanks for pyperclip!

Many moons ago (in 2012), I forked the .py from your blog post into a repo: https://github.com/timbertson/pyperclip. I haven't done that much work on it since.

I was in the process of making a `nix` package for my fork when I discovered yours is now a proper pypi / github project, and has seen a bunch of improvements since. So I'd like to decomission my fork if I can.

The only thing yours is lacking that mine had is the ability to run it from the command-line, so that cross-platform programs could just rely on `pyperclip` without necessarily being written in python.

So here's a small CLI addition, which supports `-i/--copy` and `-o/--paste` (with tests). I'm happy to discuss the CLI interface if you'd prefer something different.