### PR TITLE
Fixed extraneous output from xclip on Linux when clipboard empty

### DIFF
--- a/pyperclip/clipboards.py
+++ b/pyperclip/clipboards.py
@@ -7,19 +7,19 @@ EXCEPT_MSG = """
     For more information, please visit https://pyperclip.readthedocs.io/en/latest/introduction.html#not-implemented-error """
 PY2 = sys.version_info[0] == 2
 text_type = unicode if PY2 else str
-
+ENCODING = 'uft-8'
 
 def init_osx_clipboard():
     def copy_osx(text):
         p = subprocess.Popen(['pbcopy', 'w'],
                              stdin=subprocess.PIPE, close_fds=True)
-        p.communicate(input=text.encode('utf-8'))
+        p.communicate(input=text.encode(ENCODING))
 
     def paste_osx():
         p = subprocess.Popen(['pbpaste', 'r'],
                              stdout=subprocess.PIPE, close_fds=True)
         stdout, stderr = p.communicate()
-        return stdout.decode('utf-8')
+        return stdout.decode(ENCODING)
 
     return copy_osx, paste_osx
 
@@ -65,13 +65,14 @@ def init_xclip_clipboard():
     def copy_xclip(text):
         p = subprocess.Popen(['xclip', '-selection', 'c'],
                              stdin=subprocess.PIPE, close_fds=True)
-        p.communicate(input=text.encode('utf-8'))
+        p.communicate(input=text.encode(ENCODING))
 
     def paste_xclip():
         p = subprocess.Popen(['xclip', '-selection', 'c', '-o'],
-                             stdout=subprocess.PIPE, close_fds=True)
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
         stdout, stderr = p.communicate()
-        return stdout.decode('utf-8')
+        # Intentionally ignore extraneous output on stderr when clipboard is empty
+        return stdout.decode(ENCODING)
 
     return copy_xclip, paste_xclip
 
@@ -80,13 +81,13 @@ def init_xsel_clipboard():
     def copy_xsel(text):
         p = subprocess.Popen(['xsel', '-b', '-i'],
                              stdin=subprocess.PIPE, close_fds=True)
-        p.communicate(input=text.encode('utf-8'))
+        p.communicate(input=text.encode(ENCODING))
 
     def paste_xsel():
         p = subprocess.Popen(['xsel', '-b', '-o'],
                              stdout=subprocess.PIPE, close_fds=True)
         stdout, stderr = p.communicate()
-        return stdout.decode('utf-8')
+        return stdout.decode(ENCODING)
 
     return copy_xsel, paste_xsel
 
@@ -95,7 +96,7 @@ def init_klipper_clipboard():
     def copy_klipper(text):
         p = subprocess.Popen(
             ['qdbus', 'org.kde.klipper', '/klipper', 'setClipboardContents',
-             text.encode('utf-8')],
+             text.encode(ENCODING)],
             stdin=subprocess.PIPE, close_fds=True)
         p.communicate(input=None)
 
@@ -107,7 +108,7 @@ def init_klipper_clipboard():
 
         # Workaround for https://bugs.kde.org/show_bug.cgi?id=342874
         # TODO: https://github.com/asweigart/pyperclip/issues/43
-        clipboardContents = stdout.decode('utf-8')
+        clipboardContents = stdout.decode(ENCODING)
         # even if blank, Klipper will append a newline at the end
         assert len(clipboardContents) > 0
         # make sure that newline is there


### PR DESCRIPTION
Fixed an extra line of output on Linux when using xclip as the backend and trying to do a paste() and the clipboard is empty.

Also replaced 'utf-8' string with an ENCODING constant throughout.

This closes #97 