### PR TITLE
create /dev/clipboard implementation for cygwin,msys,etc.

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -31,7 +31,8 @@ import subprocess
 from .clipboards import (init_osx_clipboard,
                          init_gtk_clipboard, init_qt_clipboard,
                          init_xclip_clipboard, init_xsel_clipboard,
-                         init_klipper_clipboard, init_no_clipboard)
+                         init_klipper_clipboard, init_dev_clipboard,
+                         init_no_clipboard)
 from .windows import init_windows_clipboard
 
 # `import PyQt4` sys.exit()s if DISPLAY is not in the environment.
@@ -49,11 +50,7 @@ def _executable_exists(name):
 def determine_clipboard():
     # Determine the OS/platform and set
     # the copy() and paste() functions accordingly.
-    if 'cygwin' in platform.system().lower():
-        # FIXME: pyperclip currently does not support Cygwin,
-        # see https://github.com/asweigart/pyperclip/issues/55
-        pass
-    elif os.name == 'nt' or platform.system() == 'Windows':
+    if os.name == 'nt' or platform.system() == 'Windows':
         return init_windows_clipboard()
     if os.name == 'mac' or platform.system() == 'Darwin':
         return init_osx_clipboard()
@@ -79,6 +76,10 @@ def determine_clipboard():
             return init_xsel_clipboard()
         if _executable_exists("klipper") and _executable_exists("qdbus"):
             return init_klipper_clipboard()
+    # XXX this solution is better IMO than any of the HAS_DISPLAY options
+    # should it be first?
+    if os.path.exists('/dev/clipboard'):
+        return init_dev_clipboard()
 
     return init_no_clipboard()
 

--- a/pyperclip/clipboards.py
+++ b/pyperclip/clipboards.py
@@ -118,6 +118,15 @@ def init_klipper_clipboard():
 
     return copy_klipper, paste_klipper
 
+def init_dev_clipboard():
+    dc = '/dev/clipboard'
+    def copy(text):
+        with open(dc,'wt') as fo:
+            fo.write(text)
+    def paste():
+        with open(dc,'rt') as fi:
+            return fi.read()
+    return copy,paste
 
 def init_no_clipboard():
     class ClipboardUnavailable(object):


### PR DESCRIPTION
Thanks to @drakulavich for the suggestion.

fixes https://github.com/asweigart/pyperclip/issues/55
(at least for me with msys2 python3)

The new code should work anywhere /dev/clipboard exists
Using /dev/clipboard makes more sense to me even if you do have what it takes to run one of those other HAVE_DISPLAY options, but I didn't put it first because I didn't want any poorly written code to break.

I completely removed the cygwin test in platform.system() because there are at least two cygwin forks that would not match it.
