### PR TITLE
Add Termux support

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -17,8 +17,8 @@ On Windows, no additional modules are needed.
 On Mac, the module uses pbcopy and pbpaste, which should come with the os.
 On Linux, install xclip or xsel via package manager. For example, in Debian:
 sudo apt-get install xclip
-On Android, install the Termux app for terminal emulation, which include
-a copy and paste command
+On Android, install the Termux app for terminal emulation. Then install
+the Termux:API plugin, which provide support for the copy and paste commands.
 
 Otherwise on Linux, you will need the gtk or PyQt4 modules installed.
 

--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -81,7 +81,7 @@ def determine_clipboard():
             return init_xsel_clipboard()
         if _executable_exists("klipper") and _executable_exists("qdbus"):
             return init_klipper_clipboard()
-     elif _executable_exists("termux-clipboard-get"):
+    elif _executable_exists("termux-clipboard-get"):
          return init_termux_clipboard()
 
     return init_no_clipboard()

--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -25,7 +25,7 @@ Otherwise on Linux, you will need the gtk or PyQt4 modules installed.
 gtk and PyQt4 modules are not available for Python 3,
 and this module does not work with PyGObject yet.
 """
-__version__ = '1.5.27'
+__version__ = '1.6'
 
 import platform
 import os

--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -25,7 +25,7 @@ Otherwise on Linux, you will need the gtk or PyQt4 modules installed.
 gtk and PyQt4 modules are not available for Python 3,
 and this module does not work with PyGObject yet.
 """
-__version__ = '1.6.2'
+__version__ = '1.6.3'
 
 import platform
 import os

--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -25,7 +25,7 @@ Otherwise on Linux, you will need the gtk or PyQt4 modules installed.
 gtk and PyQt4 modules are not available for Python 3,
 and this module does not work with PyGObject yet.
 """
-__version__ = '1.6'
+__version__ = '1.6.1'
 
 import platform
 import os

--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -25,7 +25,7 @@ Otherwise on Linux, you will need the gtk or PyQt4 modules installed.
 gtk and PyQt4 modules are not available for Python 3,
 and this module does not work with PyGObject yet.
 """
-__version__ = '1.6.1'
+__version__ = '1.6.2'
 
 import platform
 import os

--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -82,7 +82,10 @@ def determine_clipboard():
         if _executable_exists("klipper") and _executable_exists("qdbus"):
             return init_klipper_clipboard()
     elif _executable_exists("termux-clipboard-get"):
-         return init_termux_clipboard()
+        # FIXME this command will exist even if the Termux:API plugin is not installed
+        # if it's not installed, copy and paste will just hang
+        # we need a reliable way to determine whether the plugin is installed
+        return init_termux_clipboard()
 
     return init_no_clipboard()
 

--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -17,6 +17,8 @@ On Windows, no additional modules are needed.
 On Mac, the module uses pbcopy and pbpaste, which should come with the os.
 On Linux, install xclip or xsel via package manager. For example, in Debian:
 sudo apt-get install xclip
+On Android, install the Termux app for terminal emulation, which include
+a copy and paste command
 
 Otherwise on Linux, you will need the gtk or PyQt4 modules installed.
 
@@ -28,7 +30,7 @@ __version__ = '1.5.27'
 import platform
 import os
 import subprocess
-from .clipboards import (init_osx_clipboard,
+from .clipboards import (init_osx_clipboard, init_termux_clipboard,
                          init_gtk_clipboard, init_qt_clipboard,
                          init_xclip_clipboard, init_xsel_clipboard,
                          init_klipper_clipboard, init_no_clipboard)
@@ -79,6 +81,8 @@ def determine_clipboard():
             return init_xsel_clipboard()
         if _executable_exists("klipper") and _executable_exists("qdbus"):
             return init_klipper_clipboard()
+     elif _executable_exists("termux-clipboard-get"):
+         return init_termux_clipboard()
 
     return init_no_clipboard()
 
@@ -87,6 +91,7 @@ def set_clipboard(clipboard):
     global copy, paste
 
     clipboard_types = {'osx': init_osx_clipboard,
+                       'termux': init_termux_clipboard,
                        'gtk': init_gtk_clipboard,
                        'qt': init_qt_clipboard,
                        'xclip': init_xclip_clipboard,

--- a/pyperclip/clipboards.py
+++ b/pyperclip/clipboards.py
@@ -39,7 +39,8 @@ def init_termux_clipboard():
         p = subprocess.Popen('termux-clipboard-get',
                              stdout=subprocess.PIPE, close_fds=True)
         stdout, stderr = p.communicate()
-        return stdout.decode('utf-8')
+        # get rid of the trailing newline
+        return stdout.decode('utf-8')[:-1]
 
     return copy_termux, paste_termux
 

--- a/pyperclip/clipboards.py
+++ b/pyperclip/clipboards.py
@@ -24,6 +24,26 @@ def init_osx_clipboard():
     return copy_osx, paste_osx
 
 
+def init_termux_clipboard():
+    """return a copy and paste function for Termux,
+    a terminal application for Android.
+
+    more information: https://termux.com/"""
+
+    def copy_termux(text):
+        p = subprocess.Popen('termux-clipboard-set',
+                             stdin=subprocess.PIPE, close_fds=True)
+        p.communicate(input=text.encode('utf-8'))
+
+    def paste_termux():
+        p = subprocess.Popen('termux-clipboard-get',
+                             stdout=subprocess.PIPE, close_fds=True)
+        stdout, stderr = p.communicate()
+        return stdout.decode('utf-8')
+
+    return copy_termux, paste_termux
+
+
 def init_gtk_clipboard():
     import gtk
 

--- a/tests/test_copy_paste.py
+++ b/tests/test_copy_paste.py
@@ -9,7 +9,7 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from pyperclip import _executable_exists, HAS_DISPLAY
-from pyperclip.clipboards import (init_osx_clipboard, init_termux_clipboard
+from pyperclip.clipboards import (init_osx_clipboard, init_termux_clipboard,
                                   init_gtk_clipboard, init_qt_clipboard,
                                   init_xclip_clipboard, init_xsel_clipboard,
                                   init_klipper_clipboard, init_no_clipboard)

--- a/tests/test_copy_paste.py
+++ b/tests/test_copy_paste.py
@@ -9,7 +9,7 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from pyperclip import _executable_exists, HAS_DISPLAY
-from pyperclip.clipboards import (init_osx_clipboard,
+from pyperclip.clipboards import (init_osx_clipboard, init_termux_clipboard
                                   init_gtk_clipboard, init_qt_clipboard,
                                   init_xclip_clipboard, init_xsel_clipboard,
                                   init_klipper_clipboard, init_no_clipboard)
@@ -72,6 +72,9 @@ class TestWindows(_TestClipboard):
     if os.name == 'nt' or platform.system() == 'Windows':
         clipboard = init_windows_clipboard()
 
+class TestTermux(_TestClipboard):
+    if _executable_exists('termux-clipboard-get'):
+        clipboard = init_termux_clipboard()
 
 class TestOSX(_TestClipboard):
     if os.name == 'mac' or platform.system() == 'Darwin':


### PR DESCRIPTION
Termux is a most excellent terminal emulator for Android, and using the Termux:API plugin,
users can copy and paste using the `termux-clipboard-set` and `termux-clipboard-get` commands.

This branch adds support for those commands.

Currently the whitespace test fails because the plugin does not properly copy whitespace. This is an upstream bug however.