### PR TITLE
Fix small typo in description

### DIFF
--- a/pyperclip/__init__.py
+++ b/pyperclip/__init__.py
@@ -25,7 +25,7 @@ Otherwise on Linux, you will need the gtk or PyQt5/PyQt4 modules installed.
 gtk and PyQt4 modules are not available for Python 3,
 and this module does not work with PyGObject yet.
 
-Note: There seem sto be a way to get gtk on Python 3, according to:
+Note: There seems to be a way to get gtk on Python 3, according to:
     https://askubuntu.com/questions/697397/python3-is-not-supporting-gtk-module
 
 Cygwin is currently not supported.


### PR DESCRIPTION
There's a small typo on line 28 of _pyperclip/\_\_init\_\_.py_ file:
'_seem sto_' -> '_seems to_'