### PR TITLE
Use distutils.spawn.find_executable instead

### DIFF
--- a/src/pyperclip/__init__.py
+++ b/src/pyperclip/__init__.py
@@ -47,6 +47,7 @@ __version__ = '1.7.0'
 
 import contextlib
 import ctypes
+import distutils
 import os
 import platform
 import subprocess
@@ -72,15 +73,8 @@ STR_OR_UNICODE = unicode if PY2 else str # For paste(): Python 3 uses str, Pytho
 
 ENCODING = 'utf-8'
 
-# The "which" unix command finds where a command is.
-if platform.system() == 'Windows':
-    WHICH_CMD = 'where'
-else:
-    WHICH_CMD = 'which'
-
 def _executable_exists(name):
-    return subprocess.call([WHICH_CMD, name],
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
+    return distutils.spawn.find_executable(name)
 
 
 


### PR DESCRIPTION
stdout and stderr may not always be available. The most common case of this is on Windows when using pythonw.exe instead of python.exe. This method is therefore a safer method, especially on Windows, to determine if an executable exists. See https://docs.python.org/3/library/sys.html#sys.__stderr__ for more info

Sadly, I have not been able to test this patch yet, as I have no Windows machine. It'll be trying to find a tester. If anyone else has the time, the easiest way to confirm if it works is to download Pext for Windows (https://github.com/Pext/Pext/releases/tag/v0.20), go to module -> install module -> from online module list and choose "clipboard" and ensure it doesn't crash. It uses pyperclip with this patch applied in a pythonw.exe miniconda environment.