### PR TITLE
WIP: support for wayland sessions (fix #141)

### DIFF
--- a/src/pyperclip/__init__.py
+++ b/src/pyperclip/__init__.py
@@ -72,15 +72,18 @@ STR_OR_UNICODE = unicode if PY2 else str # For paste(): Python 3 uses str, Pytho
 
 ENCODING = 'utf-8'
 
-# The "which" unix command finds where a command is.
-if platform.system() == 'Windows':
-    WHICH_CMD = 'where'
-else:
-    WHICH_CMD = 'which'
+try:
+    from shutil import which as _executable_exists
+except ImportError:
+    # The "which" unix command finds where a command is.
+    if platform.system() == 'Windows':
+        WHICH_CMD = 'where'
+    else:
+        WHICH_CMD = 'which'
 
-def _executable_exists(name):
-    return subprocess.call([WHICH_CMD, name],
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
+    def _executable_exists(name):
+        return subprocess.call([WHICH_CMD, name],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
 
 
 

--- a/tests/test_pyperclip.py
+++ b/tests/test_pyperclip.py
@@ -13,6 +13,7 @@ from pyperclip import (init_osx_pbcopy_clipboard, init_osx_pyobjc_clipboard,
                                   init_dev_clipboard_clipboard,
                                   init_gtk_clipboard, init_qt_clipboard,
                                   init_xclip_clipboard, init_xsel_clipboard,
+                                  init_wl_clipboard,
                                   init_klipper_clipboard, init_no_clipboard)
 from pyperclip import init_windows_clipboard
 from pyperclip import init_wsl_clipboard
@@ -166,6 +167,11 @@ class TestXClip(_TestClipboard):
 class TestXSel(_TestClipboard):
     if _executable_exists("xsel"):
         clipboard = init_xsel_clipboard()
+
+
+class TestWlClipboard(_TestClipboard):
+    if _executable_exists("wl-copy"):
+        clipboard = init_wl_clipboard()
 
 
 class TestKlipper(_TestClipboard):


### PR DESCRIPTION
Attempt to call `wl-copy`/`wl-paste` scripts, if on *wayland* sessions, and fix #141.

## Problems:
- 2 TCs fail due, i guess  to timing race: the `wl-copy` command forks in the background, and the result might have not yet been copied.
- SERIOUS: running all test-cases leaves behind ~4 `wl-copy` process runing each time!
  I had to ill them with `killall wl-copy`.

## Suggestion
Maybe use the `wl-copy -f` option, and launch a single 'server' process, and communicate text-to-copy with a "pumping" thread.
That would solve both issues.