### PR TITLE
Pip3 mods for Python3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@ Pyperclip is a cross-platform Python module for copy and paste clipboard functio
 
 `pip install pyperclip`
 
+**Python3.6+**
+
+`pip3 install pyperclip`
+
 Al Sweigart al@inventwithpython.com
 BSD License
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     url='https://github.com/asweigart/pyperclip',
     author='Al Sweigart',
     author_email='al@inventwithpython.com',
-    description=('A cross-platform clipboard module for Python. (Only handles plain text for now.)'),
+    description=(
+        'A cross-platform clipboard module for Python. (Only handles plain text for now.)'),
     long_description=long_description,
     license='BSD',
     packages=find_packages(where='src'),
@@ -43,5 +44,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ setup(
     url='https://github.com/asweigart/pyperclip',
     author='Al Sweigart',
     author_email='al@inventwithpython.com',
-    description=(
-        'A cross-platform clipboard module for Python. (Only handles plain text for now.)'),
+    description=('A cross-platform clipboard module for Python. (Only handles plain text for now.)'),
     long_description=long_description,
     license='BSD',
     packages=find_packages(where='src'),


### PR DESCRIPTION
Currently **pip3** is unsupported in versions of Python beyond 3.6. 

This commit should modify your **setup.py** 

I have also added documentation for the **pip3** installation process for these troubled python3.7 users

