### PR TITLE
add primary mode to determine_clipboard

### DIFF
--- a/src/pyperclip/__init__.py
+++ b/src/pyperclip/__init__.py
@@ -191,11 +191,11 @@ def init_qt_clipboard():
     return copy_qt, paste_qt
 
 
-def init_xclip_clipboard():
+def init_xclip_clipboard(primary=False):
     DEFAULT_SELECTION='c'
     PRIMARY_SELECTION='p'
 
-    def copy_xclip(text, primary=False):
+    def copy_xclip(text, primary=primary):
         text = _stringifyText(text) # Converts non-str values to str.
         selection=DEFAULT_SELECTION
         if primary:
@@ -204,7 +204,7 @@ def init_xclip_clipboard():
                              stdin=subprocess.PIPE, close_fds=True)
         p.communicate(input=text.encode(ENCODING))
 
-    def paste_xclip(primary=False):
+    def paste_xclip(primary=primary):
         selection=DEFAULT_SELECTION
         if primary:
             selection=PRIMARY_SELECTION
@@ -219,11 +219,11 @@ def init_xclip_clipboard():
     return copy_xclip, paste_xclip
 
 
-def init_xsel_clipboard():
+def init_xsel_clipboard(primary=False):
     DEFAULT_SELECTION='-b'
     PRIMARY_SELECTION='-p'
 
-    def copy_xsel(text, primary=False):
+    def copy_xsel(text, primary=primary):
         text = _stringifyText(text) # Converts non-str values to str.
         selection_flag = DEFAULT_SELECTION
         if primary:
@@ -232,7 +232,7 @@ def init_xsel_clipboard():
                              stdin=subprocess.PIPE, close_fds=True)
         p.communicate(input=text.encode(ENCODING))
 
-    def paste_xsel(primary=False):
+    def paste_xsel(primary=primary):
         selection_flag = DEFAULT_SELECTION
         if primary:
             selection_flag = PRIMARY_SELECTION
@@ -485,7 +485,7 @@ def init_wsl_clipboard():
 
 
 # Automatic detection of clipboard mechanisms and importing is done in deteremine_clipboard():
-def determine_clipboard():
+def determine_clipboard(primary=False):
     '''
     Determine the OS/platform and set the copy() and paste() functions
     accordingly.
@@ -530,9 +530,9 @@ def determine_clipboard():
             return init_gtk_clipboard()
 
         if _executable_exists("xsel"):
-            return init_xsel_clipboard()
+            return init_xsel_clipboard(primary)
         if _executable_exists("xclip"):
-            return init_xclip_clipboard()
+            return init_xclip_clipboard(primary)
         if _executable_exists("klipper") and _executable_exists("qdbus"):
             return init_klipper_clipboard()
 


### PR DESCRIPTION
Now it's possible to set primary mode, where supported, directly from determine_clipboard. By default this mode is still set to False. The remaining code is still backward compatible 