### PR TITLE
Fix for WSL2 and Ubuntu LTS 20.04

### DIFF
--- a/src/pyperclip/__init__.py
+++ b/src/pyperclip/__init__.py
@@ -509,7 +509,7 @@ def determine_clipboard():
 
     if platform.system() == 'Linux':
         with open('/proc/version', 'r') as f:
-            if "Microsoft" in f.read():
+            if "microsoft" in f.read().lower():
                 return init_wsl_clipboard()
 
     # Setup for the MAC OS X platform:


### PR DESCRIPTION
In WSL2 with an Ubuntu LTS 20.04 installation, the result of "cat /proc/versoin" contains "microsoft" in lower case. The proposed fix should work with either upper or lower case version.