### PR TITLE
Make PyQt checks in tests more specific

### DIFF
--- a/tests/test_pyperclip.py
+++ b/tests/test_pyperclip.py
@@ -146,10 +146,10 @@ class TestGtk(_TestClipboard):
 class TestQt(_TestClipboard):
     if HAS_DISPLAY:
         try:
-            import PyQt5
+            import PyQt5.QtWidgets
         except ImportError:
             try:
-                import PyQt4
+                import PyQt4.QtGui
             except ImportError:
                 pass
             else:


### PR DESCRIPTION
Test whether the widgets module can be imported rather than 'PyQt?'
in general.  The latter gives false positives if PyQt is uninstalled
but there are leftover subpackages such as qscintilla.  In this case,
Python 3 imports 'PyQt?' as a namespace.