### PR TITLE
better wayland session detection

### DIFF
--- a/src/pyperclip/__init__.py
+++ b/src/pyperclip/__init__.py
@@ -565,7 +565,7 @@ def determine_clipboard():
             return init_gtk_clipboard()
 
         if (
-                os.environ["XDG_SESSION_TYPE"] == "wayland" and
+                os.environ.get("WAYLAND_DISPLAY") and
                 _executable_exists("wl-copy")
         ):
             return init_wl_clipboard()


### PR DESCRIPTION
First of all, thanks for merging the wayland support PR! This is just a small PR for the change that I suggested earlier. I use sway as my compositor and log in via TTY. This doesn't set `XDG_SESSION_TYPE` to `wayland` so the current check would actually fail for me and other users that have a similar setup (ex. it would fail on Weston, the reference compositor as well). Instead, we can check for `WAYLAND_DISPLAY` which will always exist no matter what wayland compositor you are using.