### PR TITLE
Fail early in case problems with GObject import

### DIFF
--- a/src/pyperclip/__init__.py
+++ b/src/pyperclip/__init__.py
@@ -559,6 +559,9 @@ def determine_clipboard():
     if HAS_DISPLAY:
         try:
             import gtk  # check if gtk is installed
+            gtk.Clipboard()
+        except AttributeError:
+            pass
         except ImportError:
             pass # We want to fail fast for all non-ImportError exceptions.
         else:


### PR DESCRIPTION
Hi,

this PR fixes an issue, where pyperclip selects gtk-clipboard even if it's not really working, and then fails an exception (see below). 

This problem occurred, when I used pyperclip together with [pystray](https://pypi.org/project/pystray/) and it seems they both use conflicting ways to import GObjects. A simple call gtk.Clipboard() can detect that and pyperclip can switch to an alternative clipboard handler.

Thanks!

```bash
[...]
  File "/home/holger/coding/normcap/normcap/handlers/clipboard_handler.py", line 23, in handle
    pyperclip.copy(request.transformed)
  File "/home/holger/coding/normcap/.venv/lib/python3.8/site-packages/pyperclip/__init__.py", line 721, in lazy_load_stub_copy
    return copy(text)
  File "/home/holger/coding/normcap/.venv/lib/python3.8/site-packages/pyperclip/__init__.py", line 166, in copy_gtk
    cb = gtk.Clipboard()
  File "/home/holger/coding/normcap/.venv/lib/python3.8/site-packages/gi/__init__.py", line 69, in __getattr__
    raise AttributeError(_static_binding_error)
AttributeError: When using gi.repository you must not import static modules like "gobject". Please change all occurrences of "import gobject" to "from gi.repository import GObject". See: https://bugzilla.gnome.org/show_bug.cgi?id=709183
```