### PR TITLE
Declare support for Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37, py38, py39
 
 [testenv]
 deps =


### PR DESCRIPTION
Working for me with Python 3.9.1 on macOS 10.14 Mojave.