### PR TITLE
Improve powershell speed with '-noprofile'

### DIFF
--- a/src/pyperclip/__init__.py
+++ b/src/pyperclip/__init__.py
@@ -508,7 +508,8 @@ def init_wsl_clipboard():
         p.communicate(input=text.encode(ENCODING))
 
     def paste_wsl():
-        p = subprocess.Popen(['powershell.exe', '-command', 'Get-Clipboard'],
+        # '-noprofile' speeds up load time
+        p = subprocess.Popen(['powershell.exe', '-noprofile', '-command', 'Get-Clipboard'],
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE,
                              close_fds=True)


### PR DESCRIPTION
In WSL, loading powershell can take a long time because of profile loading, which isn't needed for pasting from the clipboard.

```bash
time -f '%E' powershell.exe -command Get-Clipboard
# 0:01.12

time -f '%E' powershell.exe -noprofile -command Get-Clipboard
# 0:00.31

# Prepared by xontrib-hist-format
```