### PR TITLE
Fixed missing GlobalLock in paste_windows function

### DIFF
--- a/src/pyperclip/__init__.py
+++ b/src/pyperclip/__init__.py
@@ -495,7 +495,10 @@ def init_windows_clipboard():
                 # (Also, it may return a handle to an empty buffer,
                 # but technically that's not empty)
                 return ""
-            return c_wchar_p(handle).value
+            locked_handle = safeGlobalLock(handle)
+            return_value = c_wchar_p(locked_handle).value
+            safeGlobalUnlock(handle)
+            return return_value
 
     return copy_windows, paste_windows
 


### PR DESCRIPTION
The missing GlobalLock caused issues when the code was running in Python interpreter embedded inside the large C++ application. The function returned rubbish in that case even it works well with the same data when running under the standalone Python process.

Tested on Windows 10 Pro v. 20H2; Python 3.9.4