### PR TITLE
docs: fix simple typo, deteremine -> determine

### DIFF
--- a/src/pyperclip/__init__.py
+++ b/src/pyperclip/__init__.py
@@ -523,7 +523,7 @@ def init_wsl_clipboard():
     return copy_wsl, paste_wsl
 
 
-# Automatic detection of clipboard mechanisms and importing is done in deteremine_clipboard():
+# Automatic detection of clipboard mechanisms and importing is done in determine_clipboard():
 def determine_clipboard():
     '''
     Determine the OS/platform and set the copy() and paste() functions


### PR DESCRIPTION
There is a small typo in src/pyperclip/__init__.py.

Should read `determine` rather than `deteremine`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md