### PR TITLE
Fix test suite for release 1.9.0

### DIFF
--- a/tests/test_pyperclip.py
+++ b/tests/test_pyperclip.py
@@ -8,7 +8,7 @@ import platform
 #import sys
 #sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from pyperclip import _executable_exists, HAS_DISPLAY
+from pyperclip import _executable_exists
 from pyperclip import (init_osx_pbcopy_clipboard, init_osx_pyobjc_clipboard,
                                   init_dev_clipboard_clipboard,
                                   init_qt_clipboard,
@@ -99,12 +99,11 @@ class _TestClipboard(unittest.TestCase):
         self.copy(False)
         self.assertEqual(self.paste(), 'False')
 
-        # All other non-str values raise an exception.
-        with self.assertRaises(PyperclipException):
-            self.copy(None)
+        self.copy(None)
+        self.assertEqual(self.paste(), 'None')
 
-        with self.assertRaises(PyperclipException):
-            self.copy([2, 4, 6, 8])
+        self.copy([2, 4, 6, 8])
+        self.assertEqual(self.paste(), '[2, 4, 6, 8]')
 
 
 class TestCygwin(_TestClipboard):
@@ -135,7 +134,7 @@ class TestOSX(_TestClipboard):
 
 
 class TestQt(_TestClipboard):
-    if HAS_DISPLAY:
+    if os.getenv("DISPLAY"):
         try:
             import PyQt5.QtWidgets
         except ImportError:


### PR DESCRIPTION
Version 1.9.0 removed `HAS_DISPLAY` and started "stringifying" all data types; the test suite needs to be updated with that in mind.

Tested with xclip.

Fixes #263.